### PR TITLE
Platform dependent library loading

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -7,11 +7,6 @@ abort unless have_header  'ruby.h'
 abort unless find_executable 'rustc'
 abort unless cargo = find_executable(ENV.fetch('CARGO', 'cargo'))
 
-target_file = 'libfastsheet.so'
-
-target =   File.join(__dir__, 'ext/fastsheet/target/release', target_file)
-lib_dest = File.join(__dir__, 'lib/fastsheet', target_file)
-
 # HACK: rubygems requires Makefile with tasks above
 File.write 'Makefile', <<EOF
 all:
@@ -23,6 +18,5 @@ $makefile_created = true
 Dir.chdir 'ext/fastsheet' do
   when_writing 'Building fastsheet...' do
     sh cargo, 'build', '--release'
-    cp target, lib_dest
   end
 end

--- a/lib/fastsheet.rb
+++ b/lib/fastsheet.rb
@@ -1,2 +1,21 @@
-require 'fastsheet/libfastsheet'
+require 'fiddle'
+
+case RUBY_PLATFORM
+
+  # Windows
+  when /win32/ then 'dll'
+
+  # OS X
+  when /darwin/ then 'dylib'
+
+  # Linux, BSD
+  else 'so'
+end.tap do |lib_ext|
+  # Load library.
+  lib = Fiddle.dlopen(File.expand_path("../../ext/fastsheet/target/release/libfastsheet.#{lib_ext}", __FILE__))
+
+  # Invoke library entry point.
+  Fiddle::Function.new(lib['Init_libfastsheet'], [], Fiddle::TYPE_VOIDP).call
+end
+
 require 'fastsheet/sheet'


### PR DESCRIPTION
`cargo build --release` produces different lib types for different platforms.

https://doc.rust-lang.org/reference/linkage.html

> --crate-type=cdylib, #[crate_type = "cdylib"] - A dynamic system library will be produced. This is used when compiling Rust code as a dynamic library to be loaded from another language. This output type will create *.so files on Linux, *.dylib files on macOS, and *.dll files on Windows.

This pull request adds OS X to supported systems. 